### PR TITLE
Number to string formatting - possible fix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,19 +177,29 @@ set(JSXER_TESTS_DATA_DIR ${JSXER_TESTS_DIR}/data)
 add_executable(jsxer-test-array-expr ${JSXER_TESTS_SRC_DIR}/array-expr.cpp)
 target_link_libraries(jsxer-test-array-expr PRIVATE ${JSXER_CORE_TARGET})
 
-add_test("ArrayExpression" jsxer-test-array-expr)
+add_test("CodeGen::ArrayExpression" jsxer-test-array-expr)
 
 add_executable(jsxer-test-obj-expr ${JSXER_TESTS_SRC_DIR}/obj-expr.cpp)
 target_link_libraries(jsxer-test-obj-expr PRIVATE ${JSXER_CORE_TARGET})
 
-add_test("ObjectExpression" jsxer-test-obj-expr)
+add_test("CodeGen::ObjectExpression" jsxer-test-obj-expr)
 
 add_executable(jsxer-test-member-expr ${JSXER_TESTS_SRC_DIR}/member-expr.cpp)
 target_link_libraries(jsxer-test-member-expr PRIVATE ${JSXER_CORE_TARGET})
 
-add_test("MemberExpression" jsxer-test-member-expr)
+add_test("CodeGen::MemberExpression" jsxer-test-member-expr)
 
 add_executable(jsxer-test-for-stmt ${JSXER_TESTS_SRC_DIR}/for-stmt.cpp)
 target_link_libraries(jsxer-test-for-stmt PRIVATE ${JSXER_CORE_TARGET})
 
-add_test("ForStatement" jsxer-test-for-stmt)
+add_test("CodeGen::ForStatement" jsxer-test-for-stmt)
+
+add_executable(jsxer-test-exp ${JSXER_TESTS_SRC_DIR}/exp.cpp)
+target_link_libraries(jsxer-test-exp PRIVATE ${JSXER_CORE_TARGET})
+
+add_test("Jsxer::Experiment" jsxer-test-exp)
+
+add_executable(n2s-formatting-test ${JSXER_TESTS_SRC_DIR}/n2s-formatting.cpp)
+target_link_libraries(n2s-formatting-test PRIVATE ${JSXER_CORE_TARGET})
+
+add_test("CodeGen::NumberFormatting" n2s-formatting-test)

--- a/include/jsxer.h
+++ b/include/jsxer.h
@@ -19,4 +19,6 @@ enum class JsxbinVersion : uint16_t {
 
 namespace jsxer {
     int decompile(const string& input, string& output, bool unblind = false);
+
+    int decompile_test(const string& input, string& output, bool unblind = false);
 }

--- a/src/jsxer/decoders.cpp
+++ b/src/jsxer/decoders.cpp
@@ -10,6 +10,12 @@ enum LiteralType {
     NUMBER,
 };
 
+enum NumberType : int {
+    kDouble = 8,
+    kInteger = 4,
+    kShort = 2,
+};
+
 string d_number_primitive(jsxer::Reader& reader, int length, bool negative) {
      vector<byte> buffer(length);
 
@@ -21,13 +27,13 @@ string d_number_primitive(jsxer::Reader& reader, int length, bool negative) {
 
     // using the length, return the appropriate interpretation of the value...
     switch (length) {
-        case 8:
+        case kDouble:
             // result is a double...
             return std::to_string(*((double *)buffer.data()) * sign);
-        case 4:
+        case kInteger:
             // result is an integer...
             return std::to_string(*((uint32_t *)buffer.data()) * sign);
-        case 2:
+        case kShort:
             // result is a short...
             return std::to_string(*((uint16_t *)buffer.data()) * sign);
         default:

--- a/src/jsxer/decoders.cpp
+++ b/src/jsxer/decoders.cpp
@@ -6,6 +6,8 @@
 #include "decoders.h"
 #include "nodes/nodes.h"
 
+#include <fmt/format.h>
+
 enum LiteralType {
     NUMBER,
 };
@@ -29,13 +31,13 @@ string d_number_primitive(jsxer::Reader& reader, int length, bool negative) {
     switch (length) {
         case kDouble:
             // result is a double...
-            return std::to_string(*((double *)buffer.data()) * sign);
+            return fmt::to_string(*((double *) buffer.data()) * sign);
         case kInteger:
             // result is an integer...
-            return std::to_string(*((uint32_t *)buffer.data()) * sign);
+            return fmt::to_string(*((uint32_t *) buffer.data()) * sign);
         case kShort:
             // result is a short...
-            return std::to_string(*((uint16_t *)buffer.data()) * sign);
+            return fmt::to_string(*((uint16_t *) buffer.data()) * sign);
         default:
             return "";
     }
@@ -67,10 +69,10 @@ string d_literal_primitive(jsxer::Reader& reader, LiteralType literalType) {
         byte num = jsxer::decoders::d_byte(reader);
 
         if (negative) {
-            return std::to_string(-1 * (int) num);
+            return fmt::to_string(-1 * (int) num);
         } else {
             if (literalType == LiteralType::NUMBER) {
-                return std::to_string((unsigned char) num);
+                return fmt::to_string((unsigned char) num);
             } else {
                 return jsxer::utils::string_literal_escape(num);
             }

--- a/src/jsxer/jsxer.cpp
+++ b/src/jsxer/jsxer.cpp
@@ -56,3 +56,24 @@ int jsxer::decompile(const string& input, string& output, bool unblind) {
 
     return 0;
 }
+
+// for testing
+int jsxer::decompile_test(const string& input, string& output, bool unblind) {
+    auto reader = std::make_unique<Reader>(input, unblind);
+
+    if (!reader->verifySignature()) {
+        // TODO: Handle this properly
+        fprintf(stderr, "JSXBIN signature verification failed!");
+        output = "";
+        return -3;
+    }
+
+    // Parse into an Ast
+    auto ast = std::make_unique<jsxer::nodes::Program>(*reader);
+    ast->parse();
+
+    // Generate code from the ast
+    output = ast->to_string();
+
+    return 0;
+}

--- a/src/jsxer/n2s.h
+++ b/src/jsxer/n2s.h
@@ -1,0 +1,5 @@
+#pragma once
+
+namespace jsxer::n2s {
+
+}

--- a/src/jsxer/reader.cpp
+++ b/src/jsxer/reader.cpp
@@ -2,6 +2,8 @@
 #include "reader.h"
 #include "util.h"
 
+#include <fmt/format.h>
+
 using namespace jsxer;
 
 Reader::Reader(const string& jsxbin, bool unblind) {
@@ -232,7 +234,7 @@ ByteString Reader::readSID(bool operator_context) {
 
         // if a symbol name is obfuscated, rename it to something more sensible...
         if (_unblind && jsxer::deob::jsxblind_should_substitute(deobfuscationContext, symbol, operator_context)) {
-            string deobfuscated = "symbol_" + std::to_string((int)id);
+            string deobfuscated = "symbol_" + fmt::to_string((int)id);
             symbol = utils::to_byte_string(deobfuscated);
         }
 

--- a/tests/src/common.h
+++ b/tests/src/common.h
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <string>
+
+#include <jsxer.h>
+
+namespace jsxer::test {
+    int decompile(const std::string& compiled, std::string& decompiled, const std::string& source = "") {
+        int err = jsxer::decompile_test(compiled, decompiled);
+
+        if (!source.empty()) {
+            printf("--------------------- Source ---------------------\n");
+            printf("%s\n", source.c_str());
+        }
+
+        printf("------------------- Decompiled -------------------\n");
+        printf("%s\n", decompiled.c_str());
+        printf("--------------------------------------------------\n");
+
+        return err;
+    }
+}

--- a/tests/src/exp.cpp
+++ b/tests/src/exp.cpp
@@ -1,0 +1,14 @@
+#include <jsxer.h>
+
+const char compiled[] = "@JSXBIN@ES@2.1@MyBbyBn0ACJAnASzBjWByBnd8lYmNmRkUlLiRiXiAftJBnAEjzFjQjSjJjOjUCfRBVBfyBffABB40BiAABAzADByB";
+
+int main() {
+    string decompiled;
+    int err = jsxer::decompile(compiled, decompiled);
+
+    printf("--------------------------------------------------\n");
+    printf("%s\n", decompiled.c_str());
+    printf("--------------------------------------------------\n");
+
+    return err;
+}

--- a/tests/src/n2s-formatting.cpp
+++ b/tests/src/n2s-formatting.cpp
@@ -1,0 +1,30 @@
+#include "./common.h"
+
+const char source[] = R"(
+var k = [
+    0,
+    123,
+    -456,
+    7.89,
+    -0.123,
+    1.23e6,
+    -4.56e-7,
+
+    1.7976931348623157e+308,
+    -1.7976931348623157e+308,
+];
+)";
+
+const char compiled[] = R"(
+@JSXBIN@ES@2.0@MyBbyBn0ABJGnASzBjLByBARJFdAFdjbFdy2mIBFd8kPmCnVhIickPgfiAFd8lQjS
+jIkRnNjclflfFd4lQmESAFd8hZhOkFhVFkakeleFd8nfnfnfnfnfnfnPjfFd8nfnfnfnfnfnfnPnffn
+ftABB40BiAABAzACByB
+)";
+
+int main() {
+    string decompiled;
+
+    int err = jsxer::test::decompile(compiled, decompiled, source);
+
+    return err;
+}


### PR DESCRIPTION
Making `fmt` lib to do the dirty work

Not sure if its `ES3` compliant.
as far as i tested it does better than our existing impl does.

Old impl is still in place opaque by control flow.