### PR TITLE
Update minimum CMake version and MacOS architectures

### DIFF
--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -79,7 +79,9 @@ jobs:
 
   build-macos-x86:
     name: Build Release for macOS (x86)
-    runs-on: macos-latest
+
+    # at the time of writing this, you need to have macos-13 in order to build for x86.
+    runs-on: macos-13
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.13.1
         with:
-          cmake-version: '3.25.2'
+          cmake-version: '3.26'
 
       - name: Configure CMake
         run: cmake .

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -46,8 +46,8 @@ jobs:
         with:
           files: jsxer-${{  github.ref_name }}-Windows.zip
 
-  build-macos:
-    name: Build Release for macOS
+  build-macos-arm64:
+    name: Build Release for macOS (arm64)
     runs-on: macos-latest
 
     steps:
@@ -69,11 +69,41 @@ jobs:
         uses: thedoctor0/zip-release@0.7.1
         with:
           type: 'zip'
-          filename: ${{ format('jsxer-{0}-macOS.zip', github.ref_name) }}
+          filename: ${{ format('jsxer-{0}-macOS-arm64.zip', github.ref_name) }}
           path: './bin/release/'
 
       - name: Attach Build Artifacts to Release
         uses: softprops/action-gh-release@v1
         with:
-          files: jsxer-${{  github.ref_name }}-macOS.zip
+          files: jsxer-${{  github.ref_name }}-macOS-arm64.zip
 
+  build-macos-x86:
+    name: Build Release for macOS (x86)
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Install CMake
+        uses: jwlawson/actions-setup-cmake@v1.13.1
+        with:
+          cmake-version: '3.26'
+
+      - name: Configure CMake
+        run: cmake .
+
+      - name: Build Project
+        run: cmake --build . --config release
+
+      - name: Zip Artifacts
+        uses: thedoctor0/zip-release@0.7.1
+        with:
+          type: 'zip'
+          filename: ${{ format('jsxer-{0}-macOS-x86.zip', github.ref_name) }}
+          path: './bin/release/'
+
+      - name: Attach Build Artifacts to Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: jsxer-${{  github.ref_name }}-macOS-x86.zip

--- a/.github/workflows/build-release.yaml
+++ b/.github/workflows/build-release.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.13.1
         with:
-          cmake-version: '3.25.2'
+          cmake-version: '3.26'
 
       - name: Configure CMake
         run: cmake .

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest-xlarge, windows-latest]
+        os: [macos-latest, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # macos arm64, macos x86_64, and windows
-        os: [macos-latest, macos-14-large, windows-latest]
+        os: [macos-latest, macos-13, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         # macos arm64, macos x86_64, and windows
-        os: [macos-latest, macos-latest-large, windows-latest]
+        os: [macos-latest, macos-14-large, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest-xlarge, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -18,7 +18,7 @@ jobs:
       - name: Install CMake
         uses: jwlawson/actions-setup-cmake@v1.13.1
         with:
-          cmake-version: '3.25.2'
+          cmake-version: '3.26'
 
       - name: Configure CMake
         run: cmake .

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -9,7 +9,8 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        # macos arm64, macos x86_64, and windows
+        os: [macos-latest, macos-latest-large, windows-latest]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -10,6 +10,7 @@ jobs:
     strategy:
       matrix:
         # macos arm64, macos x86_64, and windows
+        # at the time of writing this, you need to have macos-13 in order to build for x86.
         os: [macos-latest, macos-13, windows-latest]
 
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,15 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" BUILD_TYPE)
 
 message("Build: " "${CMAKE_BUILD_TYPE}")
 
+if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+    set(BUILD_ARCH "64-bit")
+else()
+    set(BUILD_ARCH "32-bit")
+endif()
+
+message("System Architecture: " "${CMAKE_SYSTEM_PROCESSOR}")
+message("System Bitness: " "${BUILD_ARCH}")
+
 if(MSVC OR MSYS OR MINGW)
     # for detecting Windows compilers
     set(BUILD_PLATFORM "Windows")
@@ -63,7 +72,6 @@ elseif(UNIX AND NOT APPLE)
     set(BIN_LIB_EXT ".a")
 elseif(APPLE)
     # for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
-    message("OSX Architecture: ${CMAKE_OSX_ARCHITECTURES}")
     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architecture for macOS" FORCE)
 
     set(BUILD_PLATFORM "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,8 +72,6 @@ elseif(UNIX AND NOT APPLE)
     set(BIN_LIB_EXT ".a")
 elseif(APPLE)
     # for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
-    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architecture for macOS" FORCE)
-
     set(BUILD_PLATFORM "Darwin")
 
     set(BIN_CLI_EXT "")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,7 +63,7 @@ elseif(UNIX AND NOT APPLE)
     set(BIN_LIB_EXT ".a")
 elseif(APPLE)
     # for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
-
+    message("OSX Architecture: ${CMAKE_OSX_ARCHITECTURES}")
     set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architecture for macOS" FORCE)
 
     set(BUILD_PLATFORM "Darwin")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-cmake_minimum_required(VERSION 3.20)
+cmake_minimum_required(VERSION 3.26)
+
 project(Jsxer)
 
 # using c++17 to use some modern features of c++
@@ -62,6 +63,9 @@ elseif(UNIX AND NOT APPLE)
     set(BIN_LIB_EXT ".a")
 elseif(APPLE)
     # for MacOS X or iOS, watchOS, tvOS (since 3.10.3)
+
+    set(CMAKE_OSX_ARCHITECTURES "x86_64;arm64" CACHE STRING "Build architecture for macOS" FORCE)
+
     set(BUILD_PLATFORM "Darwin")
 
     set(BIN_CLI_EXT "")


### PR DESCRIPTION
The minimum required version of CMake has been updated to 3.26. Additionally, build settings have been adjusted to force build architecture for MacOS to support both x86_64 and arm64.