### PR TITLE
Implemented functionality to decompile and inline nested JSXBIN eval calls if they contain a valid signature.

### DIFF
--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -17,6 +17,7 @@ int main(int argc, char* argv[]) {
         "JSXER - A fast and accurate JSXBIN decompiler.\n"
         "Written by Angelo DeLuca and contributors.\n",
     };
+    cli.set_version_flag("-v,--version", CONFIG_VERSION);
 
     // cli flag variables
     bool unblind = false;

--- a/src/jsxer/jsxer.cpp
+++ b/src/jsxer/jsxer.cpp
@@ -41,6 +41,7 @@ int jsxer::decompile(const string& input, string& output, bool unblind) {
 
     if (!reader->verifySignature()) {
         // TODO: Handle this properly
+        printf("[!]: %s\n", "The input file has an invalid signature.");
         fprintf(stderr, "JSXBIN signature verification failed!");
         output = "";
         return -3;

--- a/src/jsxer/nodes/CallExpression.cpp
+++ b/src/jsxer/nodes/CallExpression.cpp
@@ -1,4 +1,5 @@
 #include "CallExpression.h"
+#include "Program.h"
 
 #include <fmt/format.h>
 
@@ -10,9 +11,32 @@ namespace jsxer::nodes {
     }
 
     string CallExpression::to_string() {
+        auto function_name = function->to_string();
         auto arguments = std::dynamic_pointer_cast<ListExpression>(args);
         bool needWrap = function->type() == NodeType::FunctionExpression;
         // {new }{funcName|funcBody}({args})
+
+        if (function_name == "eval" && arguments->arguments.size() == 1 && !constructorCall) {
+            // Check if it has a JSXBIN signature.
+
+            string payload = utils::from_string_literal(arguments->arguments[0]->to_string());
+            auto internal_reader = std::make_unique<Reader>(payload, reader.should_unblind());
+
+            if (internal_reader->verifySignature()) {
+                // If we've confirmed it to be a nested JSXBIN eval call, decompile and inline the results.
+
+                auto internal_ast = std::make_unique<Program>(*internal_reader);
+                internal_ast->parse();
+                string result = internal_ast->to_string();
+
+                if (result.back() == ';') {
+                    result.pop_back();
+                }
+
+                return result;
+            }
+
+        }
 
         string result = (constructorCall ? "new " : "");
         result += (needWrap ? "(" : "")

--- a/src/jsxer/reader.cpp
+++ b/src/jsxer/reader.cpp
@@ -43,6 +43,10 @@ size_t Reader::depth() const {
     return _depth;
 }
 
+bool Reader::should_unblind() const {
+    return _unblind;
+}
+
 void Reader::step(int offset) {
     _cursor += offset;
 }
@@ -101,8 +105,6 @@ bool Reader::verifySignature() {
         _version = JsxbinVersion::v21;
     } else {
         _error = ParseError::InvalidVersion;
-        printf("[!]: %s\n", "The input file has an invalid signature.");
-
         return false;
     }
 

--- a/src/jsxer/reader.h
+++ b/src/jsxer/reader.h
@@ -73,7 +73,7 @@ public:
     [[nodiscard]] JsxbinVersion version() const;
     [[nodiscard]] ParseError error() const;
     [[nodiscard]] size_t depth() const;
-
+    [[nodiscard]] bool should_unblind() const;
     bool verifySignature();
 
     Token get();


### PR DESCRIPTION
Jsxer will now recursively decompile and inline nested JSXBIN `eval` calls.

### Output of v1.6.1:
```
eval("@JSXBIN@ES@2.1@MyBbyBn0ABJAnASzFjNjZiYiNiMByBoBFekWhcjCjPjPjLheKhAhAhAhAhAhAhAhAhAhAhAhAhAhAhcjUjJjUjMjFhAjDjMjBjTjThdhCjIjFjMjMjPifjXjPjSjMjEhCheiYiNiMhAiOjPjEjFhAiUjFjTjUhchPjUjJjUjMjFheKhAhAhAhAhAhAhAhAhAhAhAhAhAhAhcjBjVjUjIjPjShAjUjZjQjFhdhCjJifjBjNifjBjOifjBjUjUjSjJjCjVjUjFhCheiUjFjTjUhchPjBjVjUjIjPjSheKhAhAhAhAhAhAhAhAhAhAhAhAhchPjCjPjPjLheAnftABB40BiAABAzACByB");
var title = myXML.title;
eval("@JSXBIN@ES@2.1@MyBbyBn0ABJBnASzKjBjVjUjIjPjSiOjBjNjFByBXzFiAjOjBjNjFCfXzGjBjVjUjIjPjSDfjzFjNjZiYiNiMEfnftABB40BiAABAzAFByB");
```

### New Output:
```
var myXML = <book>
              <title class="hello_world">XML Node Test</title>
              <author type="i_am_an_attribute">Test</author>
            </book>;
var title = myXML.title;
var authorName = myXML.author.@name;
```